### PR TITLE
#2314 fix

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/MediaManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/MediaManager.java
@@ -318,7 +318,6 @@ public class MediaManager {
                 if(!Utils.downMixAudio(context)) {
                     mVlcPlayer.setAudioDigitalOutputEnabled(true);
                 } else {
-                    mVlcPlayer.setAudioOutput("opensles_android");
                     mVlcPlayer.setAudioOutputDevice("hdmi");
                 }
 


### PR DESCRIPTION
Seems like mentioned in a earlier issue (#786) that specifying 'setAudioOutput' prevents passtrough/auto codes selection. With this line gone 5.1 works with LibVLC in audio direct modus.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
